### PR TITLE
Fixes a bug with Exception name spacing

### DIFF
--- a/src/Fpdf/Fpdf.php
+++ b/src/Fpdf/Fpdf.php
@@ -268,7 +268,7 @@ function AliasNbPages($alias='{nb}')
 function Error($msg)
 {
 	// Fatal error
-	throw new Exception('FPDF error: '.$msg);
+	throw new \Exception('FPDF error: '.$msg);
 }
 
 function Close()

--- a/src/Fpdf/makefont/makefont.php
+++ b/src/Fpdf/makefont/makefont.php
@@ -67,7 +67,7 @@ function GetInfoFromTrueType($file, $embed, $subset, $map)
 		$ttf = new TTFParser($file);
 		$ttf->Parse();
 	}
-	catch(Exception $e)
+	catch(\Exception $e)
 	{
 		Error($e->getMessage());
 	}

--- a/src/Fpdf/makefont/ttfparser.php
+++ b/src/Fpdf/makefont/ttfparser.php
@@ -78,7 +78,7 @@ class TTFParser
 			$length = $this->ReadULong(4);
 			$this->tables[$tag] = array('offset'=>$offset, 'length'=>$length, 'checkSum'=>$checkSum);
 		}
-	}	
+	}
 
 	function ParseHead()
 	{
@@ -717,7 +717,7 @@ class TTFParser
 
 	function Error($msg)
 	{
-		throw new Exception($msg);
+		throw new \Exception($msg);
 	}
 }
 ?>


### PR DESCRIPTION
I was receiving errors saying Exception was not defined. This appears to be a name spacing issue. Please review.