### PR TITLE
avoid redefining constant

### DIFF
--- a/src/FpdfServiceProvider.php
+++ b/src/FpdfServiceProvider.php
@@ -43,7 +43,7 @@ class FpdfServiceProvider extends ServiceProvider
      */
     public function registerFpdf()
     {
-        if(config('fpdf.font_path') !== null) {
+        if(config('fpdf.font_path') !== null && !defined('FPDF_FONTPATH')) {
             define('FPDF_FONTPATH', config('fpdf.font_path'));
         }
 


### PR DESCRIPTION
When using supervisor FPDF_FONTPATH is already defined, presumably concurrent queue:work requests; so only define the constant once.