### PR TITLE
add root namespace to Exception

### DIFF
--- a/src/Fpdf/Fpdf.php
+++ b/src/Fpdf/Fpdf.php
@@ -270,7 +270,7 @@ function AliasNbPages($alias='{nb}')
 function Error($msg)
 {
 	// Fatal error
-	throw new Exception('FPDF error: '.$msg);
+	throw new \Exception('FPDF error: '.$msg);
 }
 
 function Close()


### PR DESCRIPTION
It solves the error message: Class "Codedge\Fpdf\Fpdf\Exception" not found